### PR TITLE
fix: image path handling for drag-and-drop input

### DIFF
--- a/main.py
+++ b/main.py
@@ -1142,7 +1142,7 @@ async def main():
             continue
 
         if user_input.lower() == 'image':
-            image_path = console.input("[bold cyan]Drag and drop your image here, then press enter:[/bold cyan] ").strip().replace("'", "")
+            image_path = console.input("[bold cyan]Drag and drop your image here, then press enter:[/bold cyan] ").strip(" '\"\\").replace("\\ ", " ")
 
             if os.path.isfile(image_path):
                 user_input = console.input("[bold cyan]You (prompt for image):[/bold cyan] ")


### PR DESCRIPTION
- file at `image_path` not found for valid image paths
- on MAC images with spaces are escaped with backslash characters
- Handle spaces, quotes, and backslashes in file paths