### PR TITLE
add missing prompt_toolkit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ tavily-python
 Pillow
 rich
 aiohttp
+prompt_toolkit


### PR DESCRIPTION
I think the prompt_toolkit library is missing in the requirements.txt
added it

Thank you for sharing this project!

