### PR TITLE
.gitignore: Minimal initial version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Project-specific ignores
+.env
+code_execution_env/


### PR DESCRIPTION
This includes only project-specific ignores. User (including
OS-specific) ignores may be added by each individual user to their
global .gitignore file or to the .git/info/exclude file.
