### PR TITLE
Better scanning of actual text files and automatic exclusion of files and folders in the .ignore files in the project.

### DIFF
--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -1,7 +1,4 @@
 import os
-import io
-import re
-import mimetypes
 import fnmatch
 
 class GitignoreParser:

--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -1,0 +1,78 @@
+import os
+import io
+import re
+import mimetypes
+import fnmatch
+
+class GitignoreParser:
+    def __init__(self, root_dir):
+        self.root_dir = root_dir
+        self.exclusion_rules = []
+
+    def _parse_gitignore(self, file_path, relative_path):
+        """Parses a .gitignore file and adds its patterns to the exclusion rules."""
+        patterns = []
+        with open(file_path, 'r') as f:
+            for line in f:
+                # Strip whitespace
+                line = line.strip()
+                # Ignore empty lines and comments
+                if not line or line.startswith('#'):
+                    continue
+                # Escape rules starting with literal '#'
+                if line.startswith('\\#'):
+                    line = line[1:]
+                # Handle negation
+                negate = line.startswith('!')
+                if negate:
+                    line = line[1:]
+                # Handle trailing spaces with backslash escape
+                if line.endswith('\\ '):
+                    line = line[:-1] + ' '
+                
+                # If pattern starts with /, it's relative to the directory containing the .gitignore 
+                if line.startswith('/'):
+                    pattern = os.path.join(relative_path, line[1:])
+                else:
+                    # No leading /, means it applies to all levels under the root
+                    pattern = os.path.join('**', line)
+                
+                patterns.append((negate, pattern))
+        return patterns
+
+    def _scan_directory(self, dir_path):
+        """Recursively scans directories, collecting patterns from .gitignore files."""
+        for root, dirs, files in os.walk(dir_path):
+            relative_path = os.path.relpath(root, self.root_dir)
+            gitignore_path = os.path.join(root, '.gitignore')
+            if os.path.isfile(gitignore_path):
+                patterns = self._parse_gitignore(gitignore_path, relative_path)
+                self.exclusion_rules.extend(patterns)
+
+    def add_exclusions(self, manual_exclusions):
+        self.exclusion_rules.extend(manual_exclusions)
+
+    def build_exclusion_list(self):
+        """Scans the project directory and builds a list of exclusion rules."""
+        self._scan_directory(self.root_dir)
+
+    def _match_pattern(self, pattern, path):
+        """Checks if a path matches a given pattern."""
+        # Special handling for '**' wildcards
+        if '**' in pattern:
+            # '**' can match zero or more directories
+            pattern = pattern.replace('**', '*')
+            return fnmatch.fnmatch(path, pattern)
+        # Regular pattern matching
+        return fnmatch.fnmatch(path, pattern)
+
+    def is_excluded(self, path):
+        """Determines if a given path is excluded by the .gitignore rules."""
+        # Paths must be relative to the root directory
+        relative_path = os.path.relpath(path, self.root_dir)
+        # Apply rules in order, as later rules can negate earlier ones
+        excluded = False
+        for negate, pattern in self.exclusion_rules:
+            if self._match_pattern(pattern, relative_path):
+                excluded = not negate
+        return excluded


### PR DESCRIPTION
Claude-engineer currently does a bad job at recognising text files. The mimetype approach does not recognise typical software source files such as .ts (typescript), .tsx (typescript+react), .json files and other. 

I did some research. The best generic way to check for text files is by trying to read a part of the file, as you can see in the pull request. I have tested it and it is quite fast and correctly recognises all my source files in a typescript + react project. 

Currently, too many files are registered with the scan_folder tool. My proposed improvement automatically excludes all files and folders that are listed in the `.gitignore` files in the project. I tested this thoroughly with `.gitignore` files at several levels in my project. There is still an option to manually add files or folders that need to be ignored. 

Also, would it be possible to add a LICENSE file to the project, please? An MIT or Apache 2.0 license would be great! 
