### PR TITLE
fix crash when using create_files tool

### DIFF
--- a/main.py
+++ b/main.py
@@ -1868,6 +1868,9 @@ async def chat_with_claude(user_input, image_path=None, current_iteration=None, 
         # Update the file_contents dictionary if applicable
         if tool_name in ['create_files', 'edit_and_apply_multiple', 'read_multiple_files'] and not (isinstance(tool_result, dict) and tool_result.get("is_error")):
             if tool_name == 'create_files':
+                # Convert single file dict to list for uniform handling
+                if isinstance(tool_input['files'], dict):
+                    tool_input['files'] = [tool_input['files']]
                 for file in tool_input['files']:
                     if "File created and added to system prompt" in str(tool_result):
                         file_contents[file['path']] = file['content']


### PR DESCRIPTION
- ensure `tool_input['files']` is always a list.

`claude-engineer` kept crashing with the following error
```
An unexpected error occurred: string indices must be integers
2024-11-27 11:18:18,080 - ERROR - Unexpected error: string indices must be integers
Traceback (most recent call last):
  File "/Users/user/Code/claude-engineer/main.py", line 2228, in <module>
    asyncio.run(main())
  File "/Users/user/miniconda3/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/user/miniconda3/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/Users/user/Code/claude-engineer/main.py", line 2217, in main
    response, _ = await chat_with_claude(user_input)
  File "/Users/user/Code/claude-engineer/main.py", line 1873, in chat_with_claude
    file_contents[file['path']] = file['content']
TypeError: string indices must be integers
Program finished. Goodbye!
```