### PR TITLE
added pasting of images and correct image format handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,16 +24,18 @@ def chat():
     data = request.json
     message = data.get('message', '')
     image_data = data.get('image')  # Get the base64 image data
+    media_type = data.get('media_type')  # Get the media type of the image
     
     # Prepare the message content
     if image_data:
         # Create a message with both text and image in correct order
+        
         message_content = [
             {
                 "type": "image",
                 "source": {
                     "type": "base64",
-                    "media_type": "image/jpeg",  # We should detect this from the image
+                    "media_type": media_type, 
                     "data": image_data.split(',')[1] if ',' in image_data else image_data  # Remove data URL prefix if present
                 }
             }

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -117,10 +117,15 @@ document.getElementById('file-input').addEventListener('change', async (e) => {
 });
 
 document.getElementById('remove-image').addEventListener('click', () => {
+    removeImage();
+});
+
+function removeImage() {
     currentImageData = null;
+    currentMediaType = null;
     document.getElementById('image-preview').classList.add('hidden');
     document.getElementById('file-input').value = '';
-});
+}
 
 function appendThinkingIndicator() {
     const messagesDiv = document.getElementById('chat-messages');
@@ -231,6 +236,9 @@ document.getElementById('chat-form').addEventListener('submit', async (e) => {
         imagePreview.src = `data:${currentMediaType || 'image/jpeg'};base64,${currentImageData}`;
         imagePreview.className = 'max-h-48 rounded-lg mt-2';
         document.querySelector('.message-wrapper:last-child .prose').appendChild(imagePreview);
+
+        // remove image after sending
+        removeImage();
     }
     
     // Clear input and reset height

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -8,6 +8,40 @@ textarea.addEventListener('input', function() {
     this.style.height = (this.scrollHeight) + 'px';
 });
 
+// Handle pasted images
+document.addEventListener('paste', async (e) => {
+    const items = e.clipboardData?.items;
+    
+    if (!items) return;
+    
+    for (const item of items) {
+        if (item.type.startsWith('image/')) {
+            e.preventDefault();
+            
+            const file = item.getAsFile();
+            if (!file) continue;
+            
+            try {
+                // Convert the file to base64
+                const reader = new FileReader();
+                reader.onload = async (e) => {
+                    const base64Data = e.target.result.split(',')[1];
+                    currentImageData = base64Data;
+                    currentMediaType = file.type;
+                    
+                    // Update preview
+                    document.getElementById('preview-img').src = `data:${file.type};base64,${base64Data}`;
+                    document.getElementById('image-preview').classList.remove('hidden');
+                };
+                reader.readAsDataURL(file);
+            } catch (error) {
+                console.error('Error processing pasted image:', error);
+            }
+            break;
+        }
+    }
+});
+
 function appendMessage(content, isUser = false) {
     const messagesDiv = document.getElementById('chat-messages');
     const messageWrapper = document.createElement('div');
@@ -194,7 +228,7 @@ document.getElementById('chat-form').addEventListener('submit', async (e) => {
     if (currentImageData) {
         // Optionally show the image in the chat
         const imagePreview = document.createElement('img');
-        imagePreview.src = `data:image/jpeg;base64,${currentImageData}`;
+        imagePreview.src = `data:${currentMediaType || 'image/jpeg'};base64,${currentImageData}`;
         imagePreview.className = 'max-h-48 rounded-lg mt-2';
         document.querySelector('.message-wrapper:last-child .prose').appendChild(imagePreview);
     }
@@ -214,7 +248,8 @@ document.getElementById('chat-form').addEventListener('submit', async (e) => {
             },
             body: JSON.stringify({
                 message: message,
-                image: currentImageData  // This will be null if no image is selected
+                image: currentImageData,  // This will be null if no image is selected,
+                media_type: currentMediaType
             })
         });
         
@@ -297,4 +332,4 @@ window.addEventListener('load', async () => {
     } catch (error) {
         console.error('Error resetting conversation:', error);
     }
-}); 
+});


### PR DESCRIPTION
This pull request includes enhancements to handle image uploads more effectively in the chat application. The changes primarily focus on capturing and processing the media type of images, as well as handling pasted images in the chat interface.

Enhancements to image handling:

* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R27-R38): Added support to capture the media type of images from the request data and use it when creating the message content.

* `static/js/chat.js`: 
  * Added an event listener to handle pasted images, convert them to base64, and update the preview with the correct media type.
  * Modified the image preview in the chat to use the correct media type when displaying images.
  * Updated the form submission to include the media type of the image in the request payload.