### PR TITLE
Add Daytona devcontainer and Anthropic model env

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "Claude Engineer",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+  "postCreateCommand": "python -m pip install --upgrade pip && pip install -r requirements.txt && if [ ! -f .env ]; then cp .env.example .env; fi",
+  "forwardPorts": [
+    5000
+  ],
+  "portsAttributes": {
+    "5000": {
+      "label": "Claude Engineer web UI",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python"
+      }
+    }
+  },
+  "remoteEnv": {
+    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
+    "E2B_API_KEY": "${localEnv:E2B_API_KEY}",
+    "PYTHONUNBUFFERED": "1"
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 ANTHROPIC_API_KEY=your_anthropic_api_key
+ANTHROPIC_MODEL=claude-sonnet-4-20250514
 E2B_API_KEY=your_e2b_api_key # optional

--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 class Config:
     ANTHROPIC_API_KEY = os.getenv('ANTHROPIC_API_KEY')
-    MODEL = "claude-3-5-sonnet-20241022"
+    MODEL = os.getenv('ANTHROPIC_MODEL') or "claude-sonnet-4-20250514"
     MAX_TOKENS = 8000
     MAX_CONVERSATION_TOKENS = 200000  # Maximum tokens per conversation
 


### PR DESCRIPTION
## Summary
- add a Dev Container definition for Daytona and remote development workflows
- install Python dependencies from `requirements.txt` during post-create
- copy `.env.example` to `.env` when a local environment file does not exist
- pass `ANTHROPIC_API_KEY` and `E2B_API_KEY` through from the host environment when available
- expose the Flask web UI on port `5000` for compatible development environments
- make the Claude model configurable with `ANTHROPIC_MODEL`, defaulting to `claude-sonnet-4-20250514`

## Validation
- `python3 -m json.tool .devcontainer/devcontainer.json`
- `python3 -m py_compile config.py`
- Daytona sandbox validation: dependency install, `python3 -m pip check`, `python3 -m py_compile ce3.py app.py`, CLI startup, Flask startup, and preview URL HTTP 200
- live Anthropic smoke test from inside the Daytona sandbox using an account-visible `ANTHROPIC_MODEL`, with Claude Engineer returning the expected `READY` response

Related to daytonaio/content#36.
