### PR TITLE
Add devcontainer.json for Daytona development environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "Claude Engineer",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "postCreateCommand": "pip install -r requirements.txt",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ]
+    }
+  },
+  "forwardPorts": [
+    5000
+  ],
+  "secrets": {
+    "ANTHROPIC_API_KEY": {
+      "description": "Anthropic API key for Claude"
+    },
+    "OPENAI_API_KEY": {
+      "description": "OpenAI API key (optional)"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a `.devcontainer/devcontainer.json` configuration that enables one-click setup in Daytona or VS Code.

The devcontainer:
- Uses Python 3.11 base image
- Auto-installs dependencies from requirements.txt
- Configures VS Code extensions for Python development
- Forwards port 5000 for Flask web interface
- Supports Anthropic API key as secret

This is created as part of the Daytona Content Bounty #36.