### PR TITLE
Add Daytona devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Claude Engineer",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
+  "postCreateCommand": "python -m pip install --upgrade pip uv && uv pip install --system -r requirements.txt",
+  "containerEnv": {
+    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
+    "E2B_API_KEY": "${localEnv:E2B_API_KEY}"
+  },
+  "forwardPorts": [5000],
+  "portsAttributes": {
+    "5000": {
+      "label": "Claude Engineer web UI",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["ms-python.python"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a devcontainer configuration for Daytona and other devcontainer-aware environments.
- Install project dependencies after the container is created.

## Why
This gives contributors a reproducible workspace for quickly starting the project and reproducing issues.

## Validation
- `jq empty .devcontainer/devcontainer.json`
- `git diff --check`